### PR TITLE
Implement spell projectile base and fireball ability

### DIFF
--- a/BetaOperation/BetaOperation.Build.cs
+++ b/BetaOperation/BetaOperation.Build.cs
@@ -19,10 +19,11 @@ public class BetaOperation : ModuleRules
 			"GameplayStateTreeModule",
 			"UMG",
 			"Slate",
-			"SlateCore",
-            "GameplayAbilities",
-            "GameplayTasks",
-			"GameplayTags"
+                       "SlateCore",
+           "GameplayAbilities",
+           "GameplayTasks",
+                       "GameplayTags",
+                       "Niagara"
 			
         });
 

--- a/BetaOperation/Private/BOFireballSpell.cpp
+++ b/BetaOperation/Private/BOFireballSpell.cpp
@@ -1,0 +1,64 @@
+#include "BOFireballSpell.h"
+#include "AbilitySystemBlueprintLibrary.h"
+#include "AbilitySystemComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Engine/World.h"
+#include "Engine/EngineTypes.h"
+#include "GE_FireballBurn.h"
+
+ABOFireballSpell::ABOFireballSpell()
+{
+    SpellName = TEXT("Fireball");
+    Cooldown = 0.5f;
+    DamageMagnitude = 25.f;
+    Element = FGameplayTag::RequestGameplayTag(TEXT("Element.Fire"));
+    AppliedTags.AddTag(FGameplayTag::RequestGameplayTag(TEXT("Damage.Type.Fire")));
+    BurnDotEffectClass = UGE_FireballBurn::StaticClass();
+}
+
+void ABOFireballSpell::HandleImpact(const FHitResult& SweepResult)
+{
+    if (BurnDotEffectClass)
+    {
+        float Radius = 200.f;
+        TArray<FOverlapResult> Overlaps;
+        FCollisionShape SphereShape = FCollisionShape::MakeSphere(Radius);
+        FCollisionQueryParams Params;
+        Params.AddIgnoredActor(this);
+        GetWorld()->OverlapMultiByObjectType(Overlaps, SweepResult.ImpactPoint, FQuat::Identity,
+            FCollisionObjectQueryParams(ECC_Pawn), SphereShape, Params);
+
+        for (const FOverlapResult& Res : Overlaps)
+        {
+            AActor* Actor = Res.GetActor();
+            if (!Actor || Actor == GetInstigator())
+            {
+                continue;
+            }
+
+            if (UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(Actor))
+            {
+                FGameplayEffectContextHandle Context;
+                if (SourceASC.IsValid())
+                {
+                    Context = SourceASC->MakeEffectContext();
+                    Context.AddInstigator(GetInstigator(), GetInstigator());
+                }
+                else
+                {
+                    Context = TargetASC->MakeEffectContext();
+                    Context.AddInstigator(GetInstigator(), GetInstigator());
+                }
+
+                FGameplayEffectSpecHandle DotSpec = TargetASC->MakeOutgoingSpec(BurnDotEffectClass, 1.f, Context);
+                if (DotSpec.IsValid())
+                {
+                    TargetASC->ApplyGameplayEffectSpecToSelf(*DotSpec.Data.Get());
+                }
+            }
+        }
+    }
+
+    Super::HandleImpact(SweepResult);
+}
+

--- a/BetaOperation/Private/BOSpell.cpp
+++ b/BetaOperation/Private/BOSpell.cpp
@@ -1,0 +1,134 @@
+#include "BOSpell.h"
+#include "Components/SphereComponent.h"
+#include "GameFramework/ProjectileMovementComponent.h"
+#include "Components/StaticMeshComponent.h"
+#include "AbilitySystemComponent.h"
+#include "AbilitySystemBlueprintLibrary.h"
+#include "AbilitySystemGlobals.h"
+#include "NiagaraFunctionLibrary.h"
+#include "Kismet/GameplayStatics.h"
+
+ABOSpell::ABOSpell()
+{
+    PrimaryActorTick.bCanEverTick = false;
+    bReplicates = true;
+
+    Sphere = CreateDefaultSubobject<USphereComponent>(TEXT("Sphere"));
+    Sphere->InitSphereRadius(12.f);
+    Sphere->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+    Sphere->SetCollisionResponseToAllChannels(ECR_Ignore);
+    Sphere->SetCollisionResponseToChannel(ECC_Pawn, ECR_Overlap);
+    RootComponent = Sphere;
+
+    VisualMesh = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Visual"));
+    VisualMesh->SetupAttachment(RootComponent);
+    VisualMesh->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+
+    Movement = CreateDefaultSubobject<UProjectileMovementComponent>(TEXT("Movement"));
+    Movement->InitialSpeed = 1000.f;
+    Movement->MaxSpeed = 1000.f;
+    Movement->ProjectileGravityScale = 0.f;
+    Movement->bRotationFollowsVelocity = true;
+
+    InitialLifeSpan = LifeSeconds;
+
+    SetByCallerDamageTag = FGameplayTag::RequestGameplayTag(TEXT("Data.Damage"));
+}
+
+void ABOSpell::InitializeSpell(UAbilitySystemComponent* InSourceASC, float InDamage)
+{
+    SourceASC = MakeWeakObjectPtr(InSourceASC);
+    DamageMagnitude = InDamage;
+}
+
+void ABOSpell::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (CastSFX)
+    {
+        UGameplayStatics::PlaySoundAtLocation(this, CastSFX, GetActorLocation());
+    }
+
+    if (TrailVFX)
+    {
+        UNiagaraFunctionLibrary::SpawnSystemAttached(TrailVFX, RootComponent, NAME_None,
+            FVector::ZeroVector, FRotator::ZeroRotator, EAttachLocation::KeepRelativeOffset, true);
+    }
+
+    Sphere->OnComponentBeginOverlap.AddDynamic(this, &ABOSpell::OnSphereOverlap);
+
+    if (AActor* OwnerActor = GetOwner())
+    {
+        Sphere->IgnoreActorWhenMoving(OwnerActor, true);
+    }
+    if (APawn* InstigatorPawn = GetInstigator())
+    {
+        Sphere->IgnoreActorWhenMoving(InstigatorPawn, true);
+    }
+}
+
+void ABOSpell::OnSphereOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
+    UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+    if (!OtherActor || OtherActor == GetInstigator())
+    {
+        HandleImpact(SweepResult);
+        return;
+    }
+
+    if (ImpactVFX)
+    {
+        UNiagaraFunctionLibrary::SpawnSystemAtLocation(GetWorld(), ImpactVFX, SweepResult.ImpactPoint);
+    }
+    if (ImpactSFX)
+    {
+        UGameplayStatics::PlaySoundAtLocation(this, ImpactSFX, SweepResult.ImpactPoint);
+    }
+
+    if (DamageEffectClass)
+    {
+        if (UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(OtherActor))
+        {
+            FGameplayEffectContextHandle Context;
+            if (SourceASC.IsValid())
+            {
+                Context = SourceASC->MakeEffectContext();
+                Context.AddInstigator(GetInstigator(), GetInstigator());
+            }
+            else
+            {
+                Context = UAbilitySystemGlobals::Get().AllocGameplayEffectContext();
+                Context.AddInstigator(GetInstigator(), GetInstigator());
+            }
+
+            FGameplayEffectSpecHandle SpecHandle;
+            if (SourceASC.IsValid())
+            {
+                SpecHandle = SourceASC->MakeOutgoingSpec(DamageEffectClass, 1.f, Context);
+            }
+            else
+            {
+                SpecHandle = TargetASC->MakeOutgoingSpec(DamageEffectClass, 1.f, Context);
+            }
+
+            if (SpecHandle.IsValid())
+            {
+                if (SetByCallerDamageTag.IsValid())
+                {
+                    SpecHandle.Data->SetSetByCallerMagnitude(SetByCallerDamageTag, DamageMagnitude);
+                }
+
+                TargetASC->ApplyGameplayEffectSpecToSelf(*SpecHandle.Data.Get());
+            }
+        }
+    }
+
+    HandleImpact(SweepResult);
+}
+
+void ABOSpell::HandleImpact(const FHitResult& SweepResult)
+{
+    Destroy();
+}
+

--- a/BetaOperation/Private/GE_FireballBurn.cpp
+++ b/BetaOperation/Private/GE_FireballBurn.cpp
@@ -1,0 +1,16 @@
+#include "GE_FireballBurn.h"
+#include "BOHealthAttributeSet.h"
+
+UGE_FireballBurn::UGE_FireballBurn()
+{
+    DurationPolicy = EGameplayEffectDurationType::HasDuration;
+    DurationMagnitude = FScalableFloat(4.f);
+    Period = 0.5f;
+
+    FGameplayModifierInfo Info;
+    Info.Attribute = UBOHealthAttributeSet::GetHealthAttribute();
+    Info.ModifierOp = EGameplayModOp::Additive;
+    Info.ModifierMagnitude = FScalableFloat(-5.f);
+    Modifiers.Add(Info);
+}
+

--- a/BetaOperation/Public/BOFireballSpell.h
+++ b/BetaOperation/Public/BOFireballSpell.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BOSpell.h"
+#include "BOFireballSpell.generated.h"
+
+class UGameplayEffect;
+
+/** Fireball spell with fire element and burn DOT */
+UCLASS()
+class BETAOPERATION_API ABOFireballSpell : public ABOSpell
+{
+    GENERATED_BODY()
+public:
+    ABOFireballSpell();
+
+protected:
+    // Burn damage-over-time effect
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    TSubclassOf<UGameplayEffect> BurnDotEffectClass;
+
+    virtual void HandleImpact(const FHitResult& SweepResult) override;
+};
+

--- a/BetaOperation/Public/BOSpell.h
+++ b/BetaOperation/Public/BOSpell.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "GameplayTagContainer.h"
+#include "BOSpell.generated.h"
+
+class USphereComponent;
+class UProjectileMovementComponent;
+class UAbilitySystemComponent;
+class UGameplayEffect;
+class UNiagaraSystem;
+class USoundBase;
+class UStaticMeshComponent;
+
+/** Base spell projectile that applies a GameplayEffect on overlap */
+UCLASS()
+class BETAOPERATION_API ABOSpell : public AActor
+{
+    GENERATED_BODY()
+public:
+    ABOSpell();
+
+    /** Call immediately after spawning to provide context and override damage */
+    UFUNCTION(BlueprintCallable, Category="Spell")
+    void InitializeSpell(UAbilitySystemComponent* InSourceASC, float InDamage = 25.f);
+
+protected:
+    virtual void BeginPlay() override;
+
+    /** Called when sphere overlaps another actor */
+    UFUNCTION()
+    virtual void OnSphereOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
+        UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+    /** Additional impact handling that child classes can extend (e.g., radial effects) */
+    virtual void HandleImpact(const FHitResult& SweepResult);
+
+    // --- Components ---
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    TObjectPtr<USphereComponent> Sphere;
+
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    TObjectPtr<UProjectileMovementComponent> Movement;
+
+    UPROPERTY(VisibleAnywhere, Category="Components")
+    TObjectPtr<UStaticMeshComponent> VisualMesh;
+
+    // --- Spell configuration ---
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    FString SpellName;
+
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    float ManaCost = 0.f;
+
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    float Cooldown = 0.f;
+
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    FGameplayTag Element;
+
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    FGameplayTagContainer AppliedTags;
+
+    // Damage effect to apply on hit
+    UPROPERTY(EditDefaultsOnly, Category="Damage")
+    TSubclassOf<UGameplayEffect> DamageEffectClass;
+
+    UPROPERTY(EditDefaultsOnly, Category="Damage")
+    FGameplayTag SetByCallerDamageTag;
+
+    UPROPERTY(EditAnywhere, Category="Damage")
+    float DamageMagnitude = 25.f;
+
+    // --- VFX/SFX ---
+    UPROPERTY(EditDefaultsOnly, Category="VFX")
+    TObjectPtr<UNiagaraSystem> TrailVFX;
+
+    UPROPERTY(EditDefaultsOnly, Category="VFX")
+    TObjectPtr<UNiagaraSystem> ImpactVFX;
+
+    UPROPERTY(EditDefaultsOnly, Category="SFX")
+    TObjectPtr<USoundBase> CastSFX;
+
+    UPROPERTY(EditDefaultsOnly, Category="SFX")
+    TObjectPtr<USoundBase> ImpactSFX;
+
+    // Lifetime
+    UPROPERTY(EditDefaultsOnly, Category="Spell")
+    float LifeSeconds = 3.f;
+
+    // Source ability system component for context
+    TWeakObjectPtr<UAbilitySystemComponent> SourceASC;
+};
+

--- a/BetaOperation/Public/GE_FireballBurn.h
+++ b/BetaOperation/Public/GE_FireballBurn.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayEffect.h"
+#include "GE_FireballBurn.generated.h"
+
+/** Simple burn DOT effect: 5 dmg every 0.5s for 4s */
+UCLASS()
+class BETAOPERATION_API UGE_FireballBurn : public UGameplayEffect
+{
+    GENERATED_BODY()
+public:
+    UGE_FireballBurn();
+};
+


### PR DESCRIPTION
## Summary
- add BOSpell base projectile with damage, tags, replication, and VFX/SFX hooks
- implement Fireball spell with fire element, radial burn DOT, and default damage
- define gameplay effect for burn DOT and enable Niagara module

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc101f14833192bd239e627d1ef9